### PR TITLE
Fix for multi-chain PBDs. fixes dmcskim/kinconform#3

### DIFF
--- a/kinconform
+++ b/kinconform
@@ -6,6 +6,7 @@ from subprocess import call
 from biocma import cma
 from os import chdir, getcwd, unlink
 from os.path import isfile
+import os
 import numpy as np
 from shutil import rmtree
 import pickle
@@ -58,9 +59,9 @@ def get_sequence(infile):
     univ = MDAnalysis.Universe(infile)
     prot = univ.select_atoms("protein")
     chains = [x.segid for x in prot.segments]
-    for x in chains:
-        temp_univ = prot.select_atoms("segid %s" % (x,))
-        residues = prot.residues
+    for chain in chains:
+        temp_univ = prot.select_atoms("segid %s" % (chain,))
+        residues = temp_univ.residues
         tseq = ''
         for x in residues:
             if x.resname in aas:
@@ -138,11 +139,12 @@ def do_one(args):
     fasta = open('pdbs.fasta','w')
     positions = {}
     for x in pdbs:
-        print(x)
-        temp,posn = get_sequence(x)
-        fasta.write('>'+x+'\n')
-        for y in temp:
-            fasta.write(y.format("fasta")+'\n')
+        temp, posn = get_sequence(x)
+        for chain in posn:
+            fasta.write('>'+chain+'\n')
+            s = [b for a, b in posn[chain]]
+            fasta.write(''.join(s))
+            fasta.write('\n')
         positions.update(posn)
     fasta.close()
 

--- a/kinconform
+++ b/kinconform
@@ -72,7 +72,8 @@ def get_sequence(infile):
         results.append(residues)
         tpos = list(set(temp_univ.resids))
         positions = zip(tpos,residues)
-        posn["%s_%s" % (infile, x)] = positions
+        iinfile = os.path.split(infile)[1]
+        posn["%s_%s" % (infile, chain)] = positions
     return results,posn
 
 def align_and_map_fasta(fasta, positions, basedir):

--- a/kinconform
+++ b/kinconform
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 import MDAnalysis
 from tempfile import NamedTemporaryFile


### PR DESCRIPTION
Modified the way FASTA files are written so that `kinconform` also works for PDB's with multiple chains. 

These fixes issue dmcskim/kinconform#3 and the second error mentioned in dmcskim/kinconform#2